### PR TITLE
#44 feat: 챌린지 페이지 API 구현 및 DB 데이터 Redux 연동

### DIFF
--- a/app/dashboard/records/page.tsx
+++ b/app/dashboard/records/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { useEffect } from "react";
+import axios from "axios";
+
+export interface userRecord {
+  title: string;
+  date: string;
+  challengeStatus: string;
+  description: string;
+  difficulty: number;
+}
+
+export default function Records() {
+  let [userChallenges, setUserChallenges] = useState<userRecord[]>([]);
+
+  useEffect(() => {
+    axios
+      .get("/api/records")
+      .then((res) => {
+        setUserChallenges([...res.data]);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, []);
+
+  return (
+    <div>
+      {userChallenges.map((a, i) => {
+        return (
+          <div key={i}>
+            {userChallenges[i].title}
+            {userChallenges[i].challengeStatus}
+            {userChallenges[i].date}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/pages/api/records.js
+++ b/pages/api/records.js
@@ -1,0 +1,72 @@
+import { connectDB } from "../../util/databaseConnect";
+import { ObjectId } from "mongodb";
+const jwt = require("jsonwebtoken");
+
+export default async function handler(req, res) {
+  if (req.method === "GET") {
+    // 1. authorization Header Decode
+    let atHeader = req.headers["authorization"];
+    let acToken = atHeader.substr(7);
+    let decoding = JSON.stringify(jwt.decode(acToken).id);
+    let decodeId = JSON.parse(decoding);
+
+    // 2. 해당 decodeId에 해당하는 이메일을 userAccount 에서 찾음
+    let db = (await connectDB).db("onehour");
+    let userEmail = await db
+      .collection("userAccount")
+      .findOne({ _id: new ObjectId(decodeId) });
+
+    if (userEmail === null) {
+      return res.status(403).json("요청에 대한 권한이 없습니다");
+    }
+    // 3. userChallenges  컬렉션에서 이 로그인되어있는 유저 email 에 해당하는 챌린지 정보를 가져옴
+    let userChallenges = await db
+      .collection("userChallenges")
+      .find({ email: userEmail.email })
+      .toArray();
+    // 4. 해당 데이터 리턴
+    return res.status(200).json(userChallenges);
+  } else if (req.method === "POST") {
+    const {
+      challengeStatus,
+      title,
+      description,
+      difficulty,
+      ...challengeInfo
+    } = req.body;
+
+    // 1. authorization Header Decode
+    let atHeader = req.headers["authorization"];
+    let acToken = atHeader.substr(7);
+    let decoding = JSON.stringify(jwt.decode(acToken).id);
+    let decodeId = JSON.parse(decoding);
+    let db = (await connectDB).db("onehour");
+    let userCheck = await db
+      .collection("userAccount")
+      .findOne({ _id: new ObjectId(decodeId) });
+    // 2. 해당 decodeId에 해당하는 이메일을 userAccount 에서 찾음
+    if (userCheck === null) {
+      return res.status(403).json("요청에 대한 권한이 없습니다");
+    }
+
+    // post 요청 시 연월일 계산
+    let date = new Date();
+    let year = date.getFullYear();
+    let month = date.getMonth() + 1;
+    let today = date.getDate();
+
+    let newChallenge = {
+      email: userCheck.email,
+      challengeStatus: challengeStatus,
+      title: title,
+      description: description,
+      difficulty: difficulty,
+      date: `${year}년 ${month}월 ${today}일`,
+    };
+
+    await db.collection("userChallenges").insertOne(newChallenge);
+    return res.status(200).json("챌린지 기록이 저장되었습니다");
+  } else {
+    return res.status(405).json("허용되지 않는 요청 메소드입니다");
+  }
+}


### PR DESCRIPTION
# 제목
#44 feat: 챌린지 페이지 API 구현 및 DB 데이터 Redux 연동

### 이슈 번호 : #44

## 변경 사항
- 챌린지 페이지 유저 데이터 POST API 구현
- 챌린지 페이지 유저 데이터 GET API 구현
- Redux 유저 데이터 저장 구현
- AC Token 작업 사항 merge
- refresh API 점검

## 질문 사항
- 없습니다